### PR TITLE
feat(backend): add search routes for services, triggers and actions

### DIFF
--- a/back_end/src/app/services/services.controller.ts
+++ b/back_end/src/app/services/services.controller.ts
@@ -1,5 +1,17 @@
-import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import {
   ServiceDTO,
   ActionDTO,
@@ -10,6 +22,10 @@ import {
   GetActionsByServiceResponse,
   GetActionByServiceResponse,
   GetTriggerByServiceResponse,
+  SearchServicesResponse,
+  SearchTriggersResponse,
+  SearchActionsResponse,
+  SearchAllResponse,
   type GetTriggerByServiceParams,
   type GetActionByServiceParams,
   type GetActionsByServiceParams,
@@ -93,6 +109,169 @@ export class ServiceController {
   })
   async getAllServices(): Promise<GetAllServicesResponse> {
     return this.servicesService.getAllServices();
+  }
+
+  // Search routes - must be before :serviceId route
+  @Get('search')
+  @ApiOperation({
+    summary: 'Rechercher des services par nom',
+    description:
+      'Recherche des services dont le nom contient la chaîne de recherche. Supporte la pagination avec skip et take.',
+  })
+  @ApiQuery({
+    name: 'query',
+    description: 'Terme de recherche pour le nom du service',
+    example: 'git',
+    required: true,
+  })
+  @ApiQuery({
+    name: 'skip',
+    description: "Nombre d'éléments à ignorer (pagination)",
+    example: 0,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'take',
+    description: "Nombre maximum d'éléments à retourner",
+    example: 10,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des services correspondant à la recherche',
+    type: [ServiceDTO],
+  })
+  async searchServices(
+    @Query('query') query: string,
+    @Query('skip') skip?: string,
+    @Query('take') take?: string,
+  ): Promise<SearchServicesResponse> {
+    const skipNum = skip ? parseInt(skip, 10) : undefined;
+    const takeNum = take ? parseInt(take, 10) : undefined;
+
+    return this.servicesService.searchServices(query, skipNum, takeNum);
+  }
+
+  @Get('search/triggers')
+  @ApiOperation({
+    summary: 'Rechercher des services par nom de trigger',
+    description:
+      'Recherche des services qui contiennent des triggers dont le nom correspond à la recherche. Retourne uniquement la liste des services (sans les détails des triggers).',
+  })
+  @ApiQuery({
+    name: 'query',
+    description: 'Terme de recherche pour le nom du trigger',
+    example: 'push',
+    required: true,
+  })
+  @ApiQuery({
+    name: 'skip',
+    description: "Nombre d'éléments à ignorer (pagination)",
+    example: 0,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'take',
+    description: "Nombre maximum d'éléments à retourner",
+    example: 10,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des services contenant des triggers correspondants',
+    type: [ServiceDTO],
+  })
+  async searchTriggers(
+    @Query('query') query: string,
+    @Query('skip') skip?: string,
+    @Query('take') take?: string,
+  ): Promise<SearchTriggersResponse> {
+    const skipNum = skip ? parseInt(skip, 10) : undefined;
+    const takeNum = take ? parseInt(take, 10) : undefined;
+
+    return this.servicesService.searchTriggers(query, skipNum, takeNum);
+  }
+
+  @Get('search/actions')
+  @ApiOperation({
+    summary: "Rechercher des services par nom d'action",
+    description:
+      'Recherche des services qui contiennent des actions dont le nom correspond à la recherche. Retourne uniquement la liste des services (sans les détails des actions).',
+  })
+  @ApiQuery({
+    name: 'query',
+    description: "Terme de recherche pour le nom de l'action",
+    example: 'create',
+    required: true,
+  })
+  @ApiQuery({
+    name: 'skip',
+    description: "Nombre d'éléments à ignorer (pagination)",
+    example: 0,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'take',
+    description: "Nombre maximum d'éléments à retourner",
+    example: 10,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des services contenant des actions correspondantes',
+    type: [ServiceDTO],
+  })
+  async searchActions(
+    @Query('query') query: string,
+    @Query('skip') skip?: string,
+    @Query('take') take?: string,
+  ): Promise<SearchActionsResponse> {
+    const skipNum = skip ? parseInt(skip, 10) : undefined;
+    const takeNum = take ? parseInt(take, 10) : undefined;
+
+    return this.servicesService.searchActions(query, skipNum, takeNum);
+  }
+
+  @Get('search/all')
+  @ApiOperation({
+    summary: 'Recherche globale (services, triggers, actions)',
+    description:
+      'Recherche simultanément dans les noms de services, triggers et actions. Retourne une liste unique de services qui correspondent (par nom, trigger ou action).',
+  })
+  @ApiQuery({
+    name: 'query',
+    description:
+      'Terme de recherche à appliquer sur les services, triggers et actions',
+    example: 'github',
+    required: true,
+  })
+  @ApiQuery({
+    name: 'skip',
+    description: "Nombre d'éléments à ignorer (pagination)",
+    example: 0,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'take',
+    description: "Nombre maximum d'éléments à retourner",
+    example: 10,
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Liste unique des services correspondants (dédupliqués si trouvés dans plusieurs catégories)',
+    type: [ServiceDTO],
+  })
+  async searchAll(
+    @Query('query') query: string,
+    @Query('skip') skip?: string,
+    @Query('take') take?: string,
+  ): Promise<SearchAllResponse> {
+    const skipNum = skip ? parseInt(skip, 10) : undefined;
+    const takeNum = take ? parseInt(take, 10) : undefined;
+
+    return this.servicesService.searchAll(query, skipNum, takeNum);
   }
 
   @Get(':serviceId')

--- a/back_end/src/app/services/services.dto.ts
+++ b/back_end/src/app/services/services.dto.ts
@@ -263,3 +263,43 @@ export interface GetTriggerByServiceParams {
   triggerId: string;
 }
 export type GetTriggerByServiceResponse = TriggerDTO | null;
+
+// Search DTOs
+export class SearchQueryDTO {
+  @ApiProperty({
+    description: 'Le terme de recherche',
+    example: 'github',
+    required: true,
+  })
+  query: string;
+
+  @ApiProperty({
+    description: "Nombre d'éléments à ignorer (pagination)",
+    example: 0,
+    required: false,
+    default: 0,
+  })
+  skip?: number;
+
+  @ApiProperty({
+    description: "Nombre maximum d'éléments à retourner",
+    example: 10,
+    required: false,
+  })
+  take?: number;
+}
+
+// GET /services/search?query=...&skip=...&take=...
+export type SearchServicesResponse = ServiceDTO[];
+
+// GET /services/search/triggers?query=...&skip=...&take=...
+// Retourne uniquement les services qui contiennent des triggers correspondants
+export type SearchTriggersResponse = ServiceDTO[];
+
+// GET /services/search/actions?query=...&skip=...&take=...
+// Retourne uniquement les services qui contiennent des actions correspondantes
+export type SearchActionsResponse = ServiceDTO[];
+
+// GET /services/search/all?query=...&skip=...&take=...
+// Retourne tous les services qui correspondent (par nom, trigger ou action)
+export type SearchAllResponse = ServiceDTO[];

--- a/back_end/src/app/services/services.service.ts
+++ b/back_end/src/app/services/services.service.ts
@@ -7,6 +7,11 @@ import {
   GetActionsByServiceResponse,
   GetActionByServiceResponse,
   GetTriggerByServiceResponse,
+  SearchServicesResponse,
+  SearchTriggersResponse,
+  SearchActionsResponse,
+  SearchAllResponse,
+  ServiceDTO,
 } from './services.dto';
 import { formateDate } from '@config/utils';
 
@@ -171,5 +176,172 @@ export class ServicesService {
       created_at: trigger.created_at ? formateDate(trigger.created_at) : '',
       updated_at: trigger.updated_at ? formateDate(trigger.updated_at) : '',
     };
+  }
+
+  // Search methods
+  async searchServices(
+    query: string,
+    skip?: number,
+    take?: number,
+  ): Promise<SearchServicesResponse> {
+    const whereClause = {
+      name: {
+        contains: query,
+        mode: 'insensitive' as const,
+      },
+    };
+
+    const services = await this.prisma.services.findMany({
+      where: whereClause,
+      skip: skip ?? undefined,
+      take: take ?? undefined,
+    });
+
+    return services.map((service) => ({
+      id: service.id,
+      name: service.name,
+      icon_url: service.icon_url ?? null,
+      api_base_url: service.api_base_url ?? null,
+      services_color: service.service_color,
+      auth_type: service.auth_type,
+      documentation_url: service.documentation_url ?? null,
+      is_active: service.is_active,
+      created_at: service.created_at ? formateDate(service.created_at) : '',
+    }));
+  }
+
+  async searchTriggers(
+    query: string,
+    skip?: number,
+    take?: number,
+  ): Promise<SearchTriggersResponse> {
+    const triggersWithService = await this.prisma.triggers.findMany({
+      where: {
+        name: {
+          contains: query,
+          mode: 'insensitive' as const,
+        },
+      },
+      include: {
+        service: true,
+      },
+    });
+
+    // Get unique services
+    const serviceMap = new Map<number, ServiceDTO>();
+
+    for (const trigger of triggersWithService) {
+      if (!serviceMap.has(trigger.service_id)) {
+        serviceMap.set(trigger.service_id, {
+          id: trigger.service.id,
+          name: trigger.service.name,
+          icon_url: trigger.service.icon_url ?? null,
+          api_base_url: trigger.service.api_base_url ?? null,
+          services_color: trigger.service.service_color,
+          auth_type: trigger.service.auth_type,
+          documentation_url: trigger.service.documentation_url ?? null,
+          is_active: trigger.service.is_active,
+          created_at: trigger.service.created_at
+            ? formateDate(trigger.service.created_at)
+            : '',
+        });
+      }
+    }
+
+    const services = Array.from(serviceMap.values());
+
+    // Apply pagination
+    if (skip !== undefined || take !== undefined) {
+      const start = skip ?? 0;
+      const end = take !== undefined ? start + take : undefined;
+      return services.slice(start, end);
+    }
+
+    return services;
+  }
+
+  async searchActions(
+    query: string,
+    skip?: number,
+    take?: number,
+  ): Promise<SearchActionsResponse> {
+    const actionsWithService = await this.prisma.actions.findMany({
+      where: {
+        name: {
+          contains: query,
+          mode: 'insensitive' as const,
+        },
+      },
+      include: {
+        service: true,
+      },
+    });
+
+    // Get unique services
+    const serviceMap = new Map<number, ServiceDTO>();
+
+    for (const action of actionsWithService) {
+      if (!serviceMap.has(action.service_id)) {
+        serviceMap.set(action.service_id, {
+          id: action.service.id,
+          name: action.service.name,
+          icon_url: action.service.icon_url ?? null,
+          api_base_url: action.service.api_base_url ?? null,
+          services_color: action.service.service_color,
+          auth_type: action.service.auth_type,
+          documentation_url: action.service.documentation_url ?? null,
+          is_active: action.service.is_active,
+          created_at: action.service.created_at
+            ? formateDate(action.service.created_at)
+            : '',
+        });
+      }
+    }
+
+    const services = Array.from(serviceMap.values());
+
+    // Apply pagination
+    if (skip !== undefined || take !== undefined) {
+      const start = skip ?? 0;
+      const end = take !== undefined ? start + take : undefined;
+      return services.slice(start, end);
+    }
+
+    return services;
+  }
+
+  async searchAll(
+    query: string,
+    skip?: number,
+    take?: number,
+  ): Promise<SearchAllResponse> {
+    const [servicesByName, servicesByTrigger, servicesByAction] =
+      await Promise.all([
+        this.searchServices(query, undefined, undefined),
+        this.searchTriggers(query, undefined, undefined),
+        this.searchActions(query, undefined, undefined),
+      ]);
+
+    // Merge all services and remove duplicates
+    const serviceMap = new Map<number, ServiceDTO>();
+
+    [...servicesByName, ...servicesByTrigger, ...servicesByAction].forEach(
+      (service) => {
+        if (!serviceMap.has(service.id)) {
+          serviceMap.set(service.id, service);
+        }
+      },
+    );
+
+    const allServices = Array.from(serviceMap.values());
+
+    // Apply pagination
+    if (skip !== undefined || take !== undefined) {
+      const start = skip ?? 0;
+      const end = take !== undefined ? start + take : undefined;
+      return allServices.slice(start, end);
+    }
+
+    return allServices;
   }
 }


### PR DESCRIPTION
Add 4 new search API routes with pagination support:
- GET /services/search - Search services by name
- GET /services/search/triggers - Find services containing matching triggers
- GET /services/search/actions - Find services containing matching actions
- GET /services/search/all - Global search across services, triggers and actions